### PR TITLE
fix no changes lines format bug

### DIFF
--- a/truckfactor/compute.py
+++ b/truckfactor/compute.py
@@ -148,7 +148,8 @@ def main(path_to_repo, is_url=False, commit_sha=None, ouputkind="human"):
     truckfactor, authors = compute_truck_factor(owner_df, owner_freq_df)
 
     if is_url:
-        commit_sha = get_head_commit_sha(path_to_repo)
+        if commit_sha is None:
+            commit_sha = get_head_commit_sha(path_to_repo)
         create_ouput(path_to_repo_url, commit_sha, truckfactor, authors, kind=ouputkind)
         rmtree(path_to_repo, ignore_errors=True)
     else:

--- a/truckfactor/compute.py
+++ b/truckfactor/compute.py
@@ -50,11 +50,11 @@ def write_git_log_to_file(path_to_repo, commit_sha=None):
 
     if not commit_sha:
         commit_sha = get_head_commit_sha(path_to_repo)
-    cmd = f"""git -C {path_to_repo} log {commit_sha} \
-    --pretty=format:'"%h","%an","%ad"' \
-    --date=short \
-    --numstat > \
-    {outfile}"""
+    cmd = (
+        f"git -C {path_to_repo} log {commit_sha} "
+        r'--pretty=format:"\"%h\",\"%an\",\"%ad\"" '
+        f"--date=short --numstat > {outfile}"
+    )
 
     subprocess.run(cmd, shell=True)
 

--- a/truckfactor/evo_log_to_csv.py
+++ b/truckfactor/evo_log_to_csv.py
@@ -70,8 +70,6 @@ def convert(report_file):
             commit_line = block[0]
             for csv_line in parse_numstat_block(commit_line, block[1:]):
                 fp.write(csv_line + "\n")
-
-    print(out_path)
     return out_path
 
 

--- a/truckfactor/evo_log_to_csv.py
+++ b/truckfactor/evo_log_to_csv.py
@@ -51,7 +51,7 @@ def convert(report_file):
             next_line = lines[idx + 1].rstrip()
         else:
             next_line = ""
-        if line.startswith('"') and next_line.startswith('"'):
+        if (line.startswith('\'') and next_line.startswith('\'')) or (line.startswith('"') and next_line.startswith('"')):
             # Next line is a commit too and they where no changes...
             commit_block.append(line)
             commit_blocks.append(commit_block[:])

--- a/truckfactor/evo_log_to_csv.py
+++ b/truckfactor/evo_log_to_csv.py
@@ -51,7 +51,7 @@ def convert(report_file):
             next_line = lines[idx + 1].rstrip()
         else:
             next_line = ""
-        if (line.startswith('\'') and next_line.startswith('\'')) or (line.startswith('"') and next_line.startswith('"')):
+        if line.startswith('"') and next_line.startswith('"'):
             # Next line is a commit too and they where no changes...
             commit_block.append(line)
             commit_blocks.append(commit_block[:])
@@ -70,6 +70,8 @@ def convert(report_file):
             commit_line = block[0]
             for csv_line in parse_numstat_block(commit_line, block[1:]):
                 fp.write(csv_line + "\n")
+
+    print(out_path)
     return out_path
 
 


### PR DESCRIPTION
Currently, the commit control field starts with``` ' ```instead of``` " ```as shown in the figure.
![image](https://github.com/user-attachments/assets/80385afe-9ca4-4732-b505-d4d79011117c)

The previous code will result in the following error.

```
Traceback (most recent call last):
  File "D:\envs\python\envs\truck\lib\runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "D:\envs\python\envs\truck\lib\runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "D:\envs\python\envs\truck\Scripts\truckfactor.exe\__main__.py", line 7, in <module>
  File "D:\envs\python\envs\truck\lib\site-packages\truckfactor\compute.py", line 246, in run
    truckfactor, _, _ = main(
  File "D:\envs\python\envs\truck\lib\site-packages\truckfactor\compute.py", line 145, in main
    evo_log_csv = preprocess_git_log_data(path_to_repo, commit_sha=commit_sha)
  File "D:\envs\python\envs\truck\lib\site-packages\truckfactor\compute.py", line 66, in preprocess_git_log_data
    evo_log_csv = convert(evo_log)
  File "D:\envs\python\envs\truck\lib\site-packages\truckfactor\evo_log_to_csv.py", line 71, in convert
    for csv_line in parse_numstat_block(commit_line, block[1:]):
  File "D:\envs\python\envs\truck\lib\site-packages\truckfactor\evo_log_to_csv.py", line 18, in parse_numstat_block
    added, removed, file_name = m.groups()
AttributeError: 'NoneType' object has no attribute 'groups'
```

I fix this by adding condition of ```line.startswith('\'') and next_line.startswith('\'')```. I'm not sure if this is a typo or if the format at that time was```"```, so I kept the original judgment method and use ```or``` to connect them ```(line.startswith('\'') and next_line.startswith('\'')) or (line.startswith('"') and next_line.startswith('"'))```



For the second commit,  in the original version, the output of truckfactor command will display the HEAD commit sha even though users indicated the commit sha. I fixed this bug by checking the input commit sha is None or not.